### PR TITLE
Fix several compiler errors when trying to reference type

### DIFF
--- a/fuse.d.ts
+++ b/fuse.d.ts
@@ -25,13 +25,15 @@ declare module 'fuse.js' {
     search(pattern: string): any[];
   }
 
-  export = class Fuse<T> {
+  class Fuse<T> {
     public list: T[];
     public options: FuseOptions;
 
     constructor(list: T[], options: FuseOptions);
     public set(list: T[]): T[];
     public search(pattern: string): T[];
-  };
+  }
+  
+  export = Fuse;
 }
 


### PR DESCRIPTION
Fixes the following code from typescript language service errors.

``` typescript
// tslint:disable-next-line
/// <reference path="../typings/fuse.d.ts" />

import { Injectable } from '@angular/core';

// Used for fuzzy searching
import Fuse = require('fuse.js');

import { DEMOS } from './demos.data.ts';
import { Demo } from './demo.model.ts';

@Injectable()
export class DemoService {
  private fuse: Fuse<Demo>;
  constructor () {
    this.fuse = new Fuse<Demo>(DEMOS, {
      keys: [ 'name', 'description' ]
    });
  }

  /**
   * Searches demos using a fuse.js attached to the demo name and description.
   */
  searchDemos(term: string): Demo[] {
    return this.fuse.search(term);
  }

  getDemosByName(name: string): Demo[] {
    return DEMOS.filter(demo => demo.name === name);
  }
}

```
